### PR TITLE
Update URLs for things which previously were in rust-lang-nursery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ We are always looking out for lessons to learn from high-quality Rust libraries.
 If you spot an aspect of some crate's API that you think other crates could
 benefit from, please [file an issue] to let us know.
 
-[file an issue]: https://github.com/rust-lang-nursery/api-guidelines/issues/new
+[file an issue]: https://github.com/rust-lang/api-guidelines/issues/new
 
 ## Writing content for the guidelines
 
@@ -23,7 +23,7 @@ The guidelines are written in a collection of Markdown files under the [`src`]
 directory. When making changes, you can preview the rendered content using
 [mdBook].
 
-[`src`]: https://github.com/rust-lang-nursery/api-guidelines/tree/master/src
+[`src`]: https://github.com/rust-lang/api-guidelines/tree/master/src
 [mdBook]: https://github.com/azerupi/mdBook
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ the Rust programming language. They are authored largely by the Rust
 library team, based on experiences building the Rust standard library
 and other crates in the Rust ecosystem.
 
-[Read them here](https://rust-lang-nursery.github.io/api-guidelines).
+[Read them here](https://rust-lang.github.io/api-guidelines).
 
 ## License
 

--- a/src/about.md
+++ b/src/about.md
@@ -21,5 +21,5 @@ If you are interested in contributing to the API guidelines, check out
 [contributing.md] and join our [Gitter channel].
 
 [checklist]: checklist.html
-[contributing.md]: https://github.com/rust-lang-nursery/api-guidelines/blob/master/CONTRIBUTING.md
+[contributing.md]: https://github.com/rust-lang/api-guidelines/blob/master/CONTRIBUTING.md
 [Gitter channel]: https://gitter.im/rust-impl-period/WG-libs-guidelines

--- a/src/future-proofing.md
+++ b/src/future-proofing.md
@@ -118,7 +118,7 @@ but probably not in all cases.  See the ["`impl Trait` for returning complex
 types with ease"][impl-trait-2] section of the Edition Guide for more details.
 
 [`impl Trait`]: https://github.com/rust-lang/rfcs/blob/master/text/1522-conservative-impl-trait.md
-[impl-trait-2]: https://rust-lang-nursery.github.io/edition-guide/rust-2018/trait-system/impl-trait-for-returning-complex-types-with-ease.html
+[impl-trait-2]: https://rust-lang.github.io/edition-guide/rust-2018/trait-system/impl-trait-for-returning-complex-types-with-ease.html
 
 ```rust
 pub fn my_transform<I: Iterator>(input: I) -> impl Iterator<Item = (usize, I::Item)> {

--- a/src/naming.md
+++ b/src/naming.md
@@ -11,7 +11,7 @@ traits) and `snake_case` for "value-level" constructs. More precisely:
 
 | Item | Convention |
 | ---- | ---------- |
-| Crates | [unclear](https://github.com/rust-lang-nursery/api-guidelines/issues/29) |
+| Crates | [unclear](https://github.com/rust-lang/api-guidelines/issues/29) |
 | Modules | `snake_case` |
 | Types | `UpperCamelCase` |
 | Traits | `UpperCamelCase` |
@@ -26,7 +26,7 @@ traits) and `snake_case` for "value-level" constructs. More precisely:
 | Constants | `SCREAMING_SNAKE_CASE` |
 | Type parameters | concise `UpperCamelCase`, usually single uppercase letter: `T` |
 | Lifetimes | short `lowercase`, usually a single letter: `'a`, `'de`, `'src` |
-| Features | [unclear](https://github.com/rust-lang-nursery/api-guidelines/issues/101) but see [C-FEATURE] |
+| Features | [unclear](https://github.com/rust-lang/api-guidelines/issues/101) but see [C-FEATURE] |
 
 In `UpperCamelCase`, acronyms and contractions of compound words count as one word: use `Uuid` rather than `UUID`, `Usize` rather than `USize` or `Stdin` rather than `StdIn`. In `snake_case`, acronyms and contractions are lower-cased: `is_xid_start`.
 

--- a/src/type-safety.md
+++ b/src/type-safety.md
@@ -91,7 +91,7 @@ this is often done by having each flag correspond to a particular bit, allowing
 a single integer to represent, say, 32 or 64 flags. Rust's [`bitflags`] crate
 provides a typesafe representation of this pattern.
 
-[`bitflags`]: https://github.com/rust-lang-nursery/bitflags
+[`bitflags`]: https://github.com/bitflags/bitflags
 
 ```rust
 #[macro_use]


### PR DESCRIPTION
* https://github.com/rust-lang-nursery/api-guidelines is now https://github.com/rust-lang/api-guidelines
* https://rust-lang-nursery.github.io/api-guidelines is now https://rust-lang.github.io/api-guidelines
* https://rust-lang-nursery.github.io/edition-guide is now https://rust-lang.github.io/edition-guide
* https://github.com/rust-lang-nursery/bitflags is now https://github.com/bitflags/bitflags