### PR TITLE
Rust 2018 warns when boxed Error misses dyn

### DIFF
--- a/src/documentation.md
+++ b/src/documentation.md
@@ -51,7 +51,7 @@ will not appear in user-visible rustdoc.
 /// ```rust
 /// # use std::error::Error;
 /// #
-/// # fn main() -> Result<(), Box<Error>> {
+/// # fn main() -> Result<(), Box<dyn Error>> {
 /// your;
 /// example?;
 /// code;


### PR DESCRIPTION
Sadly the warning is not visible until the doctest fails.