### PR TITLE
Fix broken link to Rust FAQ

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,4 +89,4 @@ As with all Rust-related spaces, we observe the [Rust Code of Conduct]. For
 escalation or moderation issues please contact the Rust moderation team,
 rust-mods@rust-lang.org.
 
-[Rust Code of Conduct]: https://www.rust-lang.org/conduct.html
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct

--- a/src/necessities.md
+++ b/src/necessities.md
@@ -56,7 +56,7 @@ over licensing options.
 
 [MIT]: https://github.com/rust-lang/rust/blob/master/LICENSE-MIT
 [Apache 2.0]: https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE
-[Rust FAQ]: https://www.rust-lang.org/en-US/faq.html#why-a-dual-mit-asl2-license
+[Rust FAQ]: https://prev.rust-lang.org/en-US/faq.html#why-a-dual-mit-asl2-license
 
 To apply the Rust license to your project, define the `license` field in your
 `Cargo.toml` as:


### PR DESCRIPTION
It seems the Rust FAQ was dropped with website redesign (https://github.com/rust-lang/www.rust-lang.org/issues/291). This question doesn't seem to be answered on any current resource, but the old website is still available.

Also updated link to Code of Conduct.