### PR TITLE
Add readme link to Discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,13 @@ anything to help you contribute.
 
 We are always looking out for lessons to learn from high-quality Rust libraries.
 If you spot an aspect of some crate's API that you think other crates could
-benefit from, please [file an issue] to let us know.
+benefit from, please [open a discussion] to let us know.
 
-[file an issue]: https://github.com/rust-lang/api-guidelines/issues/new
+If you'd like to propose a specific amendment to an existing guideline you can
+also [open an issue].
+
+[open a discussion]: https://github.com/rust-lang/api-guidelines/discussions/new
+[open an issue]: https://github.com/rust-lang/api-guidelines/issues/new
 
 ## Writing content for the guidelines
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ and other crates in the Rust ecosystem.
 
 [Read them here](https://rust-lang.github.io/api-guidelines).
 
+## Join the discussion
+
+See the [Discussions](https://github.com/rust-lang/api-guidelines/discussions)
+tab for proposing new API guidelines, asking questions about how to apply them,
+and for proposing new ones.
+
 ## License
 
 This project is licensed under either of [Apache License, Version


### PR DESCRIPTION
I've converted a lot of our open discussions on new guidelines into GitHub Discussions so we can keep our issue tracker focused on concrete guidelines and recommendations.

This is a new GitHub feature so users might not be used to going to Discussions yet to find things.

r? @dtolnay 