### PR TITLE
Remove readme field from C-METADATA

### DIFF
--- a/src/checklist.md
+++ b/src/checklist.md
@@ -35,7 +35,7 @@
   - [ ] Prose contains hyperlinks to relevant things ([C-LINK])
   - [ ] Cargo.toml includes all common metadata ([C-METADATA])
     - authors, description, license, homepage, documentation, repository,
-      readme, keywords, categories
+      keywords, categories
   - [ ] Crate sets html_root_url attribute "https://docs.rs/CRATE/X.Y.Z" ([C-HTML-ROOT])
   - [ ] Release notes document all significant changes ([C-RELNOTES])
   - [ ] Rustdoc does not show unhelpful implementation details ([C-HIDDEN])

--- a/src/documentation.md
+++ b/src/documentation.md
@@ -187,7 +187,6 @@ values:
 - `description`
 - `license`
 - `repository`
-- `readme`
 - `keywords`
 - `categories`
 


### PR DESCRIPTION
Since 1.46.0 (https://github.com/rust-lang/cargo/pull/8277), cargo can automatically detect the value of the readme field.

https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-readme-field

> If no value is specified for this field, and a file named README.md, README.txt or README exists in the package root, then the name of that file will be used. You can suppress this behavior by setting this field to false. If the field is set to true, a default value of README.md will be assumed.


