### PR TITLE
Fixes IntoIterator example in flexibility guidelines

### DIFF
--- a/src/flexibility.md
+++ b/src/flexibility.md
@@ -78,7 +78,7 @@ it becomes.
 Prefer
 
 ```rust
-fn foo<I: IntoIterator<Item = i64>>(iter: I) { /* ... */ }
+fn foo<I: IntoIterator<Item = &i64>>(iter: I) { /* ... */ }
 ```
 
 over any of


### PR DESCRIPTION
This is a bit of a small change, but when I was going through the Flexibility guidelines section, I noticed the `IntoIterator` example specified using `IntoIterator<Item = i64>`, but all of the original types specified implement `IntoIterator<Item = &i64>` as seen here: https://play.rust-lang.org/?gist=e5c49f401b986b822adf1210ab02f990

This PR fixes the documentation to recommend using `IntoIterator<Item = &i64>` instead.