### PR TITLE
Update code examples for serde derive in Interoperability

### DIFF
--- a/src/interoperability.md
+++ b/src/interoperability.md
@@ -155,11 +155,9 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 ```
 
 ```rust
-#[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
+use serde::{Serialize, Deserialize};
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Serialize, Deserialize)]
 struct T { /* ... */ }
 ```
 


### PR DESCRIPTION
Use 2018 Rust (e.g. removing `extern crate`)