### PR TITLE
Add Error trait to list of clear-cut nevers in c-struct-bounds

### DIFF
--- a/src/future-proofing.md
+++ b/src/future-proofing.md
@@ -172,6 +172,7 @@ The following traits should never be used in bounds on data structures:
 - `Debug`
 - `Display`
 - `Default`
+- `Error`
 - `Serialize`
 - `Deserialize`
 - `DeserializeOwned`


### PR DESCRIPTION
The std::error::Error trait broadly follows the same role as Debug and Display, and is equally inappropriate to have in bounds on a generic type parameter of a data structure.

```rust
// do not do this
pub struct S<E: Error> {...}

impl<E: Error> S<E> {...}
```

```rust
// do this
pub struct S<E> {...}

impl<E: Error> S<E> {...}
```

The typical scenario this makes a meaningful difference is in code like:

```rust
pub enum ThingError<E: Error> {
    Problem1(String),
    Problem2,
    Problem3(E),
}

// somebody else's code downstream
fn needs_retry<E>(e: &ThingError<E>) -> bool {
    match e {
        Problem1(_) => true,
        Problem2 | Problem3(_) => false,
    }
}
```

:sadface:

```console
error[E0277]: the trait bound `E: std::error::Error` is not satisfied
  --> src/lib.rs:10:22
   |
2  | pub enum ThingError<E: Error> {
   |                        ----- required by this bound in `ThingError`
...
10 | fn needs_retry<E>(e: &ThingError<E>) -> bool {
   |                      ^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `E`
```

The useless bound at the data structure is forcing downstream code to propagate the same useless bound everywhere, despite the logic of `needs_retry` having nothing to do with any of the *behavior* associated with that bound.