### PR TITLE
Replace "task failure" with "panicking" in C-DTOR-FAIL

### DIFF
--- a/src/dependability.md
+++ b/src/dependability.md
@@ -76,7 +76,7 @@ inputs are valid.
 <a id="c-dtor-fail"></a>
 ## Destructors never fail (C-DTOR-FAIL)
 
-Destructors are executed on task failure, and in that context a failing
+Destructors are executed while panicking, and in that context a failing
 destructor causes the program to abort.
 
 Instead of failing in a destructor, provide a separate method for checking for


### PR DESCRIPTION
In accordance with [RFC 221](https://github.com/rust-lang/rfcs/pull/221).