### PR TITLE
Remove authors field from C-METADATA

### DIFF
--- a/src/checklist.md
+++ b/src/checklist.md
@@ -34,7 +34,7 @@
   - [ ] Function docs include error, panic, and safety considerations ([C-FAILURE])
   - [ ] Prose contains hyperlinks to relevant things ([C-LINK])
   - [ ] Cargo.toml includes all common metadata ([C-METADATA])
-    - authors, description, license, homepage, documentation, repository,
+    - description, license, homepage, documentation, repository,
       keywords, categories
   - [ ] Release notes document all significant changes ([C-RELNOTES])
   - [ ] Rustdoc does not show unhelpful implementation details ([C-HIDDEN])

--- a/src/documentation.md
+++ b/src/documentation.md
@@ -183,7 +183,6 @@ all the things"].
 The `[package]` section of `Cargo.toml` should include the following
 values:
 
-- `authors`
 - `description`
 - `license`
 - `repository`

--- a/src/necessities.md
+++ b/src/necessities.md
@@ -65,7 +65,6 @@ To apply the Rust license to your project, define the `license` field in your
 [package]
 name = "..."
 version = "..."
-authors = ["..."]
 license = "MIT OR Apache-2.0"
 ```
 


### PR DESCRIPTION
Since [RFC3052](https://rust-lang.github.io/rfcs/3052-optional-authors-field.html), this field is effectively soft-deprecated, cargo no longer generates this field by default, and Rust's official services no longer reference this field at all.

