### PR TITLE
C-BUILDER: Avoid GNUism in example

### DIFF
--- a/src/type-safety.md
+++ b/src/type-safety.md
@@ -230,10 +230,10 @@ Command::new("/bin/cat").arg("file.txt").spawn();
 
 // Complex configuration
 let mut cmd = Command::new("/bin/ls");
-cmd.arg(".");
 if size_sorted {
     cmd.arg("-S");
 }
+cmd.arg(".");
 cmd.spawn();
 ```
 


### PR DESCRIPTION
Accepting options after a non-option argument is a glibc extension[1]. Move the option before the non-option to be POSIX compliant.

[1]: https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html#index-getopt