### PR TITLE
C-FEATURE: improve the example for conditional `no_std`

### DIFF
--- a/src/naming.md
+++ b/src/naming.md
@@ -284,8 +284,10 @@ std = []
 
 ```rust
 // In lib.rs
+#![no_std]
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "std")]
+extern crate std;
 ```
 
 Do not call the feature `use-std` or `with-std` or any creative name that is not


### PR DESCRIPTION
Nightly rustc has recently expanded the `unused_imports` lint to warn in scenarios like this (rust-lang/rust#121708):

```rust
#![cfg_attr(not(feature = "std"), no_std)]

#[cfg(feature = "alloc")]
extern crate alloc;

#[cfg(feature = "alloc")]
pub mod alloc_only {
    use alloc::boxed::Box;

    pub fn foo(_bar: Box<u8>) {}
}
```
(only gives a warning if `feature = "std"` is enabled)
<details><summary>warning</summary>

```
warning: the item `Box` is imported redundantly
   --> src/lib.rs:8:9
    |
8   |     use alloc::boxed::Box;
    |         ^^^^^^^^^^^^^^^^^
    |
   ::: /playground/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/prelude/mod.rs:125:13
    |
125 |     pub use super::v1::*;
    |             --------- the item `Box` is already defined here
    |
    = note: `#[warn(unused_imports)]` on by default
```
</details>

The underlying issue is that `#![cfg_attr(not(feature = "std"), no_std)]` will sometimes enable the `std` prelude. We should nudge people to not use the `std` prelude in `no_std` crates anymore by doing this:
```rust
#![no_std]

#[cfg(feature = "std")]
extern crate std;
```

The lint extension might be reverted again but I still think this should be the canonical way of including `std`.